### PR TITLE
Bump version to 1.2.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-credential-forwarder",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-credential-forwarder",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "MIT",
       "bin": {
         "gcf-client": "dist/gcf-client.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-credential-forwarder",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "utilities for forwarding git credential helper commands to another git installation (e.g. container to host)",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Version 1.2.9 is already published to npm. Bump to 1.2.10 to release the Dependabot security fixes from the prior commits on this branch.

https://claude.ai/code/session_011s3Y5TLFre8GUFcSuQRmnZ