### PR TITLE
Fix CI: bump pnpm to 9, drop EOL Node 18 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v7
@@ -23,7 +23,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
## Why

The last four `Run Tests` runs on `main` failed at the **Install pnpm** step:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
    at file:///home/runner/setup-pnpm/node_modules/@pnpm/exe/setup.js:64:20
Node.js v18.20.8
##[error]Something went wrong, self-installer exits with code 1
```

Dependabot #35 bumped `pnpm/action-setup` to `v6`, whose standalone self-installer for the pnpm-8 line is incompatible with **Node 18** (EOL since April 2025). Each isolated Dependabot PR check was green, but the failure surfaced once v6 landed on `main`, breaking every subsequent push.

## Fix

- Bump pnpm `version: 8` → `9` (uses a compatible `@pnpm/exe`).
- Replace EOL Node `18.x` with `22.x` LTS in the matrix (kept `20.x`).